### PR TITLE
Fix title and description fallbacks for news and events

### DIFF
--- a/src/Data/Extractor/CalendarEventsExtractor.php
+++ b/src/Data/Extractor/CalendarEventsExtractor.php
@@ -4,19 +4,15 @@ declare(strict_types=1);
 
 namespace Hofff\Contao\SocialTags\Data\Extractor;
 
+use Contao\CalendarEventsModel;
 use Contao\Controller;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Contao\File;
 use Contao\FilesModel;
 use Contao\Model;
 use Contao\News;
-use Contao\CalendarEventsModel;
 use Contao\PageModel;
-use Hofff\Contao\SocialTags\Data\Extractor;
-use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphImageData;
-use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphType;
-use Hofff\Contao\SocialTags\Util\TypeUtil;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Contao\StringUtil;
 use function explode;
 use function is_file;
 use function method_exists;
@@ -24,6 +20,11 @@ use function str_replace;
 use function strip_tags;
 use function trim;
 use function ucfirst;
+use Hofff\Contao\SocialTags\Data\Extractor;
+use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphImageData;
+use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphType;
+use Hofff\Contao\SocialTags\Util\TypeUtil;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 final class CalendarEventsExtractor implements Extractor
 {
@@ -75,12 +76,7 @@ final class CalendarEventsExtractor implements Extractor
             return $this->replaceInsertTags($title);
         }
 
-        $title = $eventModel->title;
-        if (TypeUtil::isStringWithContent($title)) {
-            return $this->replaceInsertTags($title);
-        }
-
-        return null;
+        return $this->getEventTitle($eventModel) ?: null;
     }
 
     private function extractTwitterSite(CalendarEventsModel $evemtModel) : ?string
@@ -94,10 +90,7 @@ final class CalendarEventsExtractor implements Extractor
             return $this->replaceInsertTags($eventModel->hofff_st_twitter_description);
         }
 
-        $description = $eventModel->description;
-        $description = trim(str_replace(["\n", "\r"], [' ', ''], $description));
-
-        return $description ?: null;
+        return $this->getEventDescription($eventModel) ?: null;
     }
 
     private function extractTwitterImage(CalendarEventsModel $calendarEventsModel) : ?string
@@ -145,12 +138,7 @@ final class CalendarEventsExtractor implements Extractor
             return $this->replaceInsertTags($title);
         }
 
-        $title = $calendarEventsModel->title;
-        if (TypeUtil::isStringWithContent($title)) {
-            return $this->replaceInsertTags($title);
-        }
-
-        return null;
+        return $this->getEventTitle($calendarEventsModel) ?: null;
     }
 
     private function extractOpenGraphUrl(CalendarEventsModel $calendarEventsModel) : string
@@ -172,10 +160,7 @@ final class CalendarEventsExtractor implements Extractor
             return $this->replaceInsertTags($calendarEventsModel->hofff_st_og_description);
         }
 
-        $description = $calendarEventsModel->description;
-        $description = trim(str_replace(["\n", "\r"], [' ', ''], $description));
-
-        return $description ?: null;
+        return $this->getEventDescription($calendarEventsModel) ?: null;
     }
 
     private function extractOpenGraphSiteName(CalendarEventsModel $calendarEventsModel, PageModel $fallback) : string
@@ -238,5 +223,31 @@ final class CalendarEventsExtractor implements Extractor
         }
 
         return $request->getRequestUri();
+    }
+
+    /**
+     * Returns the meta description if present, otherwise the shortened teaser.
+     */
+    private function getEventDescription(CalendarEventsModel $model): string
+    {
+        if (!empty($model->description)) {
+            return $this->replaceInsertTags(trim(str_replace(["\n", "\r"], [' ', ''], $model->description)));
+        }
+
+        // Generate the description from the teaser the same way as the event reader does
+        $description = $this->replaceInsertTags($model->teaser, false);
+		$description = strip_tags($description);
+		$description = str_replace("\n", ' ', $description);
+        $description = StringUtil::substr($description, 320);
+        
+        return $description;
+    }
+
+    /**
+     * Returns the meta title if present, otherwise the title.
+     */
+    private function getEventTitle(CalendarEventsModel $model): string
+    {
+        return $this->replaceInsertTags($model->pageTitle ?: $model->title);
     }
 }

--- a/src/Data/Extractor/CalendarEventsExtractor.php
+++ b/src/Data/Extractor/CalendarEventsExtractor.php
@@ -236,8 +236,8 @@ final class CalendarEventsExtractor implements Extractor
 
         // Generate the description from the teaser the same way as the event reader does
         $description = $this->replaceInsertTags($model->teaser, false);
-		$description = strip_tags($description);
-		$description = str_replace("\n", ' ', $description);
+        $description = strip_tags($description);
+        $description = str_replace("\n", ' ', $description);
         $description = StringUtil::substr($description, 320);
         
         return $description;

--- a/src/Data/Extractor/CalendarEventsExtractor.php
+++ b/src/Data/Extractor/CalendarEventsExtractor.php
@@ -76,7 +76,7 @@ final class CalendarEventsExtractor implements Extractor
             return $this->replaceInsertTags($title);
         }
 
-        return $this->getEventTitle($eventModel) ?: null;
+        return $this->getEventTitle($eventModel);
     }
 
     private function extractTwitterSite(CalendarEventsModel $evemtModel) : ?string
@@ -230,7 +230,7 @@ final class CalendarEventsExtractor implements Extractor
      */
     private function getEventDescription(CalendarEventsModel $model) : string
     {
-        if (! empty($model->description)) {
+        if (TypeUtil::isStringWithContent($model->description)) {
             return $this->replaceInsertTags(trim(str_replace(["\n", "\r"], [' ', ''], $model->description)));
         }
 
@@ -246,8 +246,13 @@ final class CalendarEventsExtractor implements Extractor
     /**
      * Returns the meta title if present, otherwise the title.
      */
-    private function getEventTitle(CalendarEventsModel $model) : string
+    private function getEventTitle(CalendarEventsModel $model) : ?string
     {
-        return $this->replaceInsertTags($model->pageTitle ?: $model->title);
+        $title = $model->pageTitle ?: $model->title;
+        if (TypeUtil::isStringWithContent($title)) {	
+            return $this->replaceInsertTags($title);	
+        }
+        
+        return null;
     }
 }

--- a/src/Data/Extractor/CalendarEventsExtractor.php
+++ b/src/Data/Extractor/CalendarEventsExtractor.php
@@ -13,6 +13,11 @@ use Contao\Model;
 use Contao\News;
 use Contao\PageModel;
 use Contao\StringUtil;
+use Hofff\Contao\SocialTags\Data\Extractor;
+use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphImageData;
+use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphType;
+use Hofff\Contao\SocialTags\Util\TypeUtil;
+use Symfony\Component\HttpFoundation\RequestStack;
 use function explode;
 use function is_file;
 use function method_exists;
@@ -20,11 +25,6 @@ use function str_replace;
 use function strip_tags;
 use function trim;
 use function ucfirst;
-use Hofff\Contao\SocialTags\Data\Extractor;
-use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphImageData;
-use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphType;
-use Hofff\Contao\SocialTags\Util\TypeUtil;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 final class CalendarEventsExtractor implements Extractor
 {
@@ -228,9 +228,9 @@ final class CalendarEventsExtractor implements Extractor
     /**
      * Returns the meta description if present, otherwise the shortened teaser.
      */
-    private function getEventDescription(CalendarEventsModel $model): string
+    private function getEventDescription(CalendarEventsModel $model) : string
     {
-        if (!empty($model->description)) {
+        if (! empty($model->description)) {
             return $this->replaceInsertTags(trim(str_replace(["\n", "\r"], [' ', ''], $model->description)));
         }
 
@@ -239,14 +239,14 @@ final class CalendarEventsExtractor implements Extractor
         $description = strip_tags($description);
         $description = str_replace("\n", ' ', $description);
         $description = StringUtil::substr($description, 320);
-        
+
         return $description;
     }
 
     /**
      * Returns the meta title if present, otherwise the title.
      */
-    private function getEventTitle(CalendarEventsModel $model): string
+    private function getEventTitle(CalendarEventsModel $model) : string
     {
         return $this->replaceInsertTags($model->pageTitle ?: $model->title);
     }

--- a/src/Data/Extractor/NewsExtractor.php
+++ b/src/Data/Extractor/NewsExtractor.php
@@ -12,11 +12,7 @@ use Contao\Model;
 use Contao\News;
 use Contao\NewsModel;
 use Contao\PageModel;
-use Hofff\Contao\SocialTags\Data\Extractor;
-use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphImageData;
-use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphType;
-use Hofff\Contao\SocialTags\Util\TypeUtil;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Contao\StringUtil;
 use function explode;
 use function is_file;
 use function method_exists;
@@ -24,6 +20,11 @@ use function str_replace;
 use function strip_tags;
 use function trim;
 use function ucfirst;
+use Hofff\Contao\SocialTags\Data\Extractor;
+use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphImageData;
+use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphType;
+use Hofff\Contao\SocialTags\Util\TypeUtil;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 final class NewsExtractor implements Extractor
 {
@@ -75,12 +76,7 @@ final class NewsExtractor implements Extractor
             return $this->replaceInsertTags($title);
         }
 
-        $title = $newsModel->headline;
-        if (TypeUtil::isStringWithContent($title)) {
-            return $this->replaceInsertTags($title);
-        }
-
-        return null;
+        return $this->getNewsTitle($newsModel) ?: null;
     }
 
     private function extractTwitterSite(NewsModel $newsModel) : ?string
@@ -94,10 +90,7 @@ final class NewsExtractor implements Extractor
             return $this->replaceInsertTags($newsModel->hofff_st_twitter_description);
         }
 
-        $description = $newsModel->description;
-        $description = trim(str_replace(["\n", "\r"], [' ', ''], $description));
-
-        return $description ?: null;
+        return $this->getNewsDescription($newsModel) ?: null;
     }
 
     private function extractTwitterImage(NewsModel $newsModel) : ?string
@@ -145,12 +138,7 @@ final class NewsExtractor implements Extractor
             return $this->replaceInsertTags($title);
         }
 
-        $title = $newsModel->headline;
-        if (TypeUtil::isStringWithContent($title)) {
-            return $this->replaceInsertTags($title);
-        }
-
-        return null;
+        return $this->getNewsTitle($newsModel) ?: null;
     }
 
     private function extractOpenGraphUrl(NewsModel $newsModel) : string
@@ -172,10 +160,7 @@ final class NewsExtractor implements Extractor
             return $this->replaceInsertTags($newsModel->hofff_st_og_description);
         }
 
-        $description = $newsModel->description;
-        $description = trim(str_replace(["\n", "\r"], [' ', ''], $description));
-
-        return $description ?: null;
+        return $this->getNewsDescription($newsModel);
     }
 
     private function extractOpenGraphSiteName(NewsModel $newsModel, PageModel $fallback) : string
@@ -238,5 +223,31 @@ final class NewsExtractor implements Extractor
         }
 
         return $request->getRequestUri();
+    }
+
+    /**
+     * Returns the meta description if present, otherwise the shortened teaser.
+     */
+    private function getNewsDescription(NewsModel $model): string
+    {
+        if (!empty($model->description)) {
+            return $this->replaceInsertTags(trim(str_replace(["\n", "\r"], [' ', ''], $model->description)));
+        }
+
+        // Generate the description from the teaser the same way as the news reader does
+        $description = $this->replaceInsertTags($model->teaser, false);
+		$description = strip_tags($description);
+		$description = str_replace("\n", ' ', $description);
+        $description = StringUtil::substr($description, 320);
+        
+        return $description;
+    }
+
+    /**
+     * Returns the meta title if present, otherwise the headline.
+     */
+    private function getNewsTitle(NewsModel $model): string
+    {
+        return $this->replaceInsertTags($model->pageTitle ?: $model->headline);
     }
 }

--- a/src/Data/Extractor/NewsExtractor.php
+++ b/src/Data/Extractor/NewsExtractor.php
@@ -76,7 +76,7 @@ final class NewsExtractor implements Extractor
             return $this->replaceInsertTags($title);
         }
 
-        return $this->getNewsTitle($newsModel) ?: null;
+        return $this->getNewsTitle($newsModel);
     }
 
     private function extractTwitterSite(NewsModel $newsModel) : ?string
@@ -230,7 +230,7 @@ final class NewsExtractor implements Extractor
      */
     private function getNewsDescription(NewsModel $model) : string
     {
-        if (! empty($model->description)) {
+        if (TypeUtil::isStringWithContent($model->description)) {
             return $this->replaceInsertTags(trim(str_replace(["\n", "\r"], [' ', ''], $model->description)));
         }
 
@@ -246,8 +246,13 @@ final class NewsExtractor implements Extractor
     /**
      * Returns the meta title if present, otherwise the headline.
      */
-    private function getNewsTitle(NewsModel $model) : string
+    private function getNewsTitle(NewsModel $model) : ?string
     {
-        return $this->replaceInsertTags($model->pageTitle ?: $model->headline);
+        $title = $model->pageTitle ?: $model->headline;
+        if (TypeUtil::isStringWithContent($title)) {	
+            return $this->replaceInsertTags($title);	
+        }
+        
+        return null;
     }
 }

--- a/src/Data/Extractor/NewsExtractor.php
+++ b/src/Data/Extractor/NewsExtractor.php
@@ -160,7 +160,7 @@ final class NewsExtractor implements Extractor
             return $this->replaceInsertTags($newsModel->hofff_st_og_description);
         }
 
-        return $this->getNewsDescription($newsModel);
+        return $this->getNewsDescription($newsModel) ?: null;
     }
 
     private function extractOpenGraphSiteName(NewsModel $newsModel, PageModel $fallback) : string

--- a/src/Data/Extractor/NewsExtractor.php
+++ b/src/Data/Extractor/NewsExtractor.php
@@ -13,6 +13,11 @@ use Contao\News;
 use Contao\NewsModel;
 use Contao\PageModel;
 use Contao\StringUtil;
+use Hofff\Contao\SocialTags\Data\Extractor;
+use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphImageData;
+use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphType;
+use Hofff\Contao\SocialTags\Util\TypeUtil;
+use Symfony\Component\HttpFoundation\RequestStack;
 use function explode;
 use function is_file;
 use function method_exists;
@@ -20,11 +25,6 @@ use function str_replace;
 use function strip_tags;
 use function trim;
 use function ucfirst;
-use Hofff\Contao\SocialTags\Data\Extractor;
-use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphImageData;
-use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphType;
-use Hofff\Contao\SocialTags\Util\TypeUtil;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 final class NewsExtractor implements Extractor
 {
@@ -228,9 +228,9 @@ final class NewsExtractor implements Extractor
     /**
      * Returns the meta description if present, otherwise the shortened teaser.
      */
-    private function getNewsDescription(NewsModel $model): string
+    private function getNewsDescription(NewsModel $model) : string
     {
-        if (!empty($model->description)) {
+        if (! empty($model->description)) {
             return $this->replaceInsertTags(trim(str_replace(["\n", "\r"], [' ', ''], $model->description)));
         }
 
@@ -239,14 +239,14 @@ final class NewsExtractor implements Extractor
         $description = strip_tags($description);
         $description = str_replace("\n", ' ', $description);
         $description = StringUtil::substr($description, 320);
-        
+
         return $description;
     }
 
     /**
      * Returns the meta title if present, otherwise the headline.
      */
-    private function getNewsTitle(NewsModel $model): string
+    private function getNewsTitle(NewsModel $model) : string
     {
         return $this->replaceInsertTags($model->pageTitle ?: $model->headline);
     }

--- a/src/Data/Extractor/NewsExtractor.php
+++ b/src/Data/Extractor/NewsExtractor.php
@@ -236,8 +236,8 @@ final class NewsExtractor implements Extractor
 
         // Generate the description from the teaser the same way as the news reader does
         $description = $this->replaceInsertTags($model->teaser, false);
-		$description = strip_tags($description);
-		$description = str_replace("\n", ' ', $description);
+        $description = strip_tags($description);
+        $description = str_replace("\n", ' ', $description);
         $description = StringUtil::substr($description, 320);
         
         return $description;


### PR DESCRIPTION
This PR fixes the following things for the News and Event Extractor:

* The _extract…Description_ methods used `description` as the fallback. However, that field is only available in Contao **4.9+**, but not in Contao **4.4**. This PR uses the `description` field as the first fallback if present and otherwise generates the description from the `teaser` the same way as Contao does.
* The _extract…Title_ methods only used the `title`/`headline` as the fallback. However, in Contao **4.9+** we also have the `pageTitle` field for news and events, which will be used for the meta information instead. This PR uses the `pageTitle` field as the first fallback if present and otherwise falls back to the `title`/`headline`.

I can undo the sorting of the use statements again if necessary (it's just my IDE that did it automatically).