### PR TITLE
Fix URL generation for faq, news & events

### DIFF
--- a/src/Data/Extractor/CalendarEventsExtractor.php
+++ b/src/Data/Extractor/CalendarEventsExtractor.php
@@ -7,6 +7,7 @@ namespace Hofff\Contao\SocialTags\Data\Extractor;
 use Contao\CalendarEventsModel;
 use Contao\Controller;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\Events;
 use Contao\File;
 use Contao\FilesModel;
 use Contao\Model;
@@ -164,7 +165,7 @@ final class CalendarEventsExtractor implements Extractor
             return $this->getBaseUrl() . $this->getRequestUri();
         }
 
-        $eventUrl = News::generateNewsUrl($calendarEventsModel, false, true);
+        $eventUrl = Events::generateEventUrl($calendarEventsModel, true);
 
         // Prepend scheme and host if URL is not absolute
         if (stripos($eventUrl, 'http') !== 0) {

--- a/src/Data/Extractor/CalendarEventsExtractor.php
+++ b/src/Data/Extractor/CalendarEventsExtractor.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Hofff\Contao\SocialTags\Data\Extractor;
 
+use Contao\CalendarEventsModel;
 use Contao\Controller;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
 use Contao\File;
 use Contao\FilesModel;
 use Contao\Model;
 use Contao\News;
-use Contao\CalendarEventsModel;
 use Contao\PageModel;
 use Hofff\Contao\SocialTags\Data\Extractor;
 use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphImageData;
@@ -22,6 +22,7 @@ use function is_file;
 use function method_exists;
 use function str_replace;
 use function strip_tags;
+use function stripos;
 use function trim;
 use function ucfirst;
 
@@ -163,7 +164,14 @@ final class CalendarEventsExtractor implements Extractor
             return $this->getBaseUrl() . $this->getRequestUri();
         }
 
-        return News::generateNewsUrl($calendarEventsModel, false, true);
+        $eventUrl = News::generateNewsUrl($calendarEventsModel, false, true);
+
+        // Prepend scheme and host if URL is not absolute
+        if (stripos($eventUrl, 'http') !== 0) {
+            $eventUrl = $this->getBaseUrl() . $eventUrl;
+        }
+
+        return $eventUrl;
     }
 
     private function extractOpenGraphDescription(CalendarEventsModel $calendarEventsModel) : ?string

--- a/src/Data/Extractor/FaqExtractor.php
+++ b/src/Data/Extractor/FaqExtractor.php
@@ -6,11 +6,11 @@ namespace Hofff\Contao\SocialTags\Data\Extractor;
 
 use Contao\Controller;
 use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\FaqModel;
 use Contao\File;
 use Contao\FilesModel;
 use Contao\Model;
 use Contao\News;
-use Contao\FaqModel;
 use Contao\PageModel;
 use Hofff\Contao\SocialTags\Data\Extractor;
 use Hofff\Contao\SocialTags\Data\OpenGraph\OpenGraphImageData;
@@ -20,9 +20,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use function explode;
 use function is_file;
 use function method_exists;
-use function str_replace;
 use function strip_tags;
-use function trim;
+use function stripos;
 use function ucfirst;
 
 final class FaqExtractor implements Extractor
@@ -160,7 +159,14 @@ final class FaqExtractor implements Extractor
             return $this->getBaseUrl() . $this->getRequestUri();
         }
 
-        return News::generateNewsUrl($faqModel, false, true);
+        $faqUrl = News::generateNewsUrl($faqModel, false, true);
+
+        // Prepend scheme and host if URL is not absolute
+        if (stripos($faqUrl, 'http') !== 0) {
+            $faqUrl = $this->getBaseUrl() . $faqUrl;
+        }
+
+        return $faqUrl;
     }
 
     private function extractOpenGraphDescription(FaqModel $faqModel) : ?string

--- a/src/Data/Extractor/NewsExtractor.php
+++ b/src/Data/Extractor/NewsExtractor.php
@@ -22,6 +22,7 @@ use function is_file;
 use function method_exists;
 use function str_replace;
 use function strip_tags;
+use function stripos;
 use function trim;
 use function ucfirst;
 
@@ -163,7 +164,14 @@ final class NewsExtractor implements Extractor
             return $this->getBaseUrl() . $this->getRequestUri();
         }
 
-        return News::generateNewsUrl($newsModel, false, true);
+        $newsUrl = News::generateNewsUrl($newsModel, false, true);
+
+        // Prepend scheme and host if URL is not absolute
+        if (stripos($newsUrl, 'http') !== 0) {
+            $newsUrl = $this->getBaseUrl() . $newsUrl;
+        }
+
+        return $newsUrl;
     }
 
     private function extractOpenGraphDescription(NewsModel $newsModel) : ?string


### PR DESCRIPTION
Currently the URL generated for faq, news and events is not necessarily an absolute URL, since `News::generateNewsUrl` uses `getFrontendUrl` and not `getAbsoluteUrl` - and `getFrontendUrl` only returns an absolute URL, if the current domain differs from the generated domain.

This PR prepends the scheme and host if the generated URL is not absolute.