### PR TITLE
Do not use XHTML

### DIFF
--- a/src/Data/Property.php
+++ b/src/Data/Property.php
@@ -45,7 +45,7 @@ class Property
 
         if ($this->namespace && $this->prefix) {
             return sprintf(
-                '<meta%s property="%s" content="%s" />',
+                '<meta%s property="%s" content="%s">',
                 sprintf(' prefix="%s"', specialchars($this->getNamespaceDeclaration())),
                 specialchars($this->getPrefixedName()),
                 specialchars($this->content)
@@ -53,7 +53,7 @@ class Property
         }
 
         return sprintf(
-            '<meta property="%s" content="%s" />',
+            '<meta property="%s" content="%s">',
             specialchars($this->getPrefixedName()),
             specialchars($this->content)
         );


### PR DESCRIPTION
Support for XHTML has been dropped in Contao 4 and since this extensions requires at least Contao 4.4, there is no need to use it (nor check for it). This would bring the output in line with the rest of the `<meta>` tags.