### PR TITLE
Fix type error

### DIFF
--- a/src/Data/Extractor/CalendarEventsExtractor.php
+++ b/src/Data/Extractor/CalendarEventsExtractor.php
@@ -237,10 +237,14 @@ final class CalendarEventsExtractor implements Extractor
     /**
      * Returns the meta description if present, otherwise the shortened teaser.
      */
-    private function getEventDescription(CalendarEventsModel $model) : string
+    private function getEventDescription(CalendarEventsModel $model) : ?string
     {
         if (TypeUtil::isStringWithContent($model->description)) {
             return $this->replaceInsertTags(trim(str_replace(["\n", "\r"], [' ', ''], $model->description)));
+        }
+
+        if (! TypeUtil::isStringWithContent($model->teaser)) {
+            return null;
         }
 
         // Generate the description from the teaser the same way as the event reader does

--- a/src/Data/Extractor/NewsExtractor.php
+++ b/src/Data/Extractor/NewsExtractor.php
@@ -236,10 +236,14 @@ final class NewsExtractor implements Extractor
     /**
      * Returns the meta description if present, otherwise the shortened teaser.
      */
-    private function getNewsDescription(NewsModel $model) : string
+    private function getNewsDescription(NewsModel $model) : ?string
     {
         if (TypeUtil::isStringWithContent($model->description)) {
             return $this->replaceInsertTags(trim(str_replace(["\n", "\r"], [' ', ''], $model->description)));
+        }
+
+        if (! TypeUtil::isStringWithContent($model->teaser)) {
+            return null;
         }
 
         // Generate the description from the teaser the same way as the news reader does


### PR DESCRIPTION
On a customer's installation, the teaser can be null for some reason, resulting in the following error:

```
ErrorException: Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Argument 1 passed to Hofff\Contao\SocialTags\Data\Extractor\NewsExtractor::replaceInsertTags() must be of the type string, null given, called in …/htdocs/vendor/hofff/contao-social-tags/src/Data/Extractor/NewsExtractor.php on line 246 in …/htdocs/vendor/hofff/contao-social-tags/src/Data/Extractor/NewsExtractor.php:198
Stack trace:
#0 …/htdocs/vendor/hofff/contao-social-tags/src/Data/Extractor/NewsExtractor.php(246): Hofff\Contao\SocialTags\Data\Extractor\NewsExtractor->replaceInsertTags(NULL, false)
#1 …/htdocs/vendor/hofff/contao-social-tags/src/Data/Extractor/NewsExtractor.php(171): Hofff\Contao\SocialTags\Data\Extractor\NewsExtractor->getNewsDescription(Object(NewsCategories\NewsModel))
#2 …/htdocs/vendor/hofff/contao-social-tags/src/Data/Extractor/NewsExtractor.php(67): Hofff\Contao\SocialTags\Data\Extractor\News
#1 vendor/hofff/contao-social-tags/src/Data/Extractor/NewsExtractor.php(198): handleFatalError
#0 vendor/sentry/sentry/lib/Raven/ErrorHandler.php(0): null
```

This PR also checks if there is actual content in the teaser.