### PR TITLE
Fix Twitter Card defaults and fallback

### DIFF
--- a/src/Data/TwitterCards/TwitterCardsFactory.php
+++ b/src/Data/TwitterCards/TwitterCardsFactory.php
@@ -26,7 +26,7 @@ final class TwitterCardsFactory implements DataFactory
             return new Protocol();
         }
 
-        switch ($reference->hofff_st_twitter_type) {
+        switch ($reference->hofff_st_twitter_type ?: $fallback->hofff_st_twitter_type) {
             case 'hofff_st_twitter_summary':
                 return new SummaryCardData(
                     $this->extractor->extract('twitter', 'title', $reference, $fallback),

--- a/src/Resources/contao/dca/tl_calendar_events.php
+++ b/src/Resources/contao/dca/tl_calendar_events.php
@@ -133,7 +133,6 @@ $GLOBALS['TL_DCA']['tl_calendar_events']['fields']['hofff_st_twitter_type'] = [
     'label'     => &$GLOBALS['TL_LANG']['hofff_st']['hofff_st_twitter_type'],
     'exclude'   => true,
     'inputType' => 'select',
-    'default'   => 'website',
     'options'   => ['hofff_st_twitter_summary', 'hofff_st_twitter_summary_large_image'],
     'reference' => &$GLOBALS['TL_LANG']['hofff_st']['hofff_st_twitter_types'],
     'eval'      => [

--- a/src/Resources/contao/dca/tl_faq.php
+++ b/src/Resources/contao/dca/tl_faq.php
@@ -130,7 +130,6 @@ $GLOBALS['TL_DCA']['tl_faq']['fields']['hofff_st_twitter_type'] = [
     'label'     => &$GLOBALS['TL_LANG']['hofff_st']['hofff_st_twitter_type'],
     'exclude'   => true,
     'inputType' => 'select',
-    'default'   => 'website',
     'options'   => ['hofff_st_twitter_summary', 'hofff_st_twitter_summary_large_image'],
     'reference' => &$GLOBALS['TL_LANG']['hofff_st']['hofff_st_twitter_types'],
     'eval'      => [

--- a/src/Resources/contao/dca/tl_news.php
+++ b/src/Resources/contao/dca/tl_news.php
@@ -130,7 +130,6 @@ $GLOBALS['TL_DCA']['tl_news']['fields']['hofff_st_twitter_type'] = [
     'label'     => &$GLOBALS['TL_LANG']['hofff_st']['hofff_st_twitter_type'],
     'exclude'   => true,
     'inputType' => 'select',
-    'default'   => 'website',
     'options'   => ['hofff_st_twitter_summary', 'hofff_st_twitter_summary_large_image'],
     'reference' => &$GLOBALS['TL_LANG']['hofff_st']['hofff_st_twitter_types'],
     'eval'      => [

--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -156,7 +156,6 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['hofff_st_twitter_type'] = [
     'label'     => &$GLOBALS['TL_LANG']['hofff_st']['hofff_st_twitter_type'],
     'exclude'   => true,
     'inputType' => 'select',
-    'default'   => 'website',
     'options'   => ['hofff_st_twitter_summary', 'hofff_st_twitter_summary_large_image'],
     'reference' => &$GLOBALS['TL_LANG']['hofff_st']['hofff_st_twitter_types'],
     'eval'      => [


### PR DESCRIPTION
This PR fixes the erroneous defaults for `hofff_st_twitter_type` in the DCA - and the fallback for `hofff_st_twitter_type` in the `TwitterCardsFactory`.