### PR TITLE
Fix Twitter Cards when no Twitter username is present

### DIFF
--- a/src/Data/TwitterCards/CardData.php
+++ b/src/Data/TwitterCards/CardData.php
@@ -68,10 +68,7 @@ abstract class CardData extends AbstractData
     private function getImageData() : Protocol
     {
         $protocol = new Protocol();
-
-        if ($this->site) {
-            $protocol->add(new Property(null, 'image', $this->image, 'twitter'));
-        }
+        $protocol->add(new Property(null, 'image', $this->image, 'twitter'));
 
         return $protocol;
     }
@@ -79,10 +76,7 @@ abstract class CardData extends AbstractData
     private function getTitleData() : Protocol
     {
         $protocol = new Protocol();
-
-        if ($this->site) {
-            $protocol->add(new Property(null, 'title', $this->title, 'twitter'));
-        }
+        $protocol->add(new Property(null, 'title', $this->title, 'twitter'));
 
         return $protocol;
     }
@@ -90,10 +84,7 @@ abstract class CardData extends AbstractData
     private function getDescriptionData() : Protocol
     {
         $protocol = new Protocol();
-
-        if ($this->site) {
-            $protocol->add(new Property(null, 'description', $this->description, 'twitter'));
-        }
+        $protocol->add(new Property(null, 'description', $this->description, 'twitter'));
 
         return $protocol;
     }


### PR DESCRIPTION
The `twitter:site` property is optional for Twitter Cards (see https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image - only `twitter:card` and `twitter:title` are mandatory). However the current implementation basically omits all properties (except `twitter:card`) if no site information is present (i.e. the Twitter username).

This PR removes the check for the site for the affected properties.