### PR TITLE
string cant be null error

### DIFF
--- a/src/EventListener/Hook/NewsReaderListener.php
+++ b/src/EventListener/Hook/NewsReaderListener.php
@@ -42,8 +42,12 @@ final class NewsReaderListener extends SocialTagsDataAwareListener
         $this->framework    = $framework;
     }
 
-    public function onGetContentElement(Model $model, string $result): string
+    public function onGetContentElement(Model $model, ?string $result): string
     {
+        if (null === $result) {
+            $result = "";
+        }
+
         if ($model->type !== 'module') {
             return $result;
         }


### PR DESCRIPTION
fix for

[2021-05-18 13:57:54] app.CRITICAL: An exception occurred. {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: Argument 2 passed to Hofff\\Contao\\SocialTags\\EventListener\\Hook\\NewsReaderListener::onGetContentElement() must be of the type string, null given, called in /var/www/html/staging/vendor/contao/core-bundle/src/Resources/contao/library/Contao/Controller.php on line 484 at /var/www/html/staging/vendor/hofff/contao-social-tags/src/EventListener/Hook/NewsReaderListener.php:43)"} []