### PR TITLE
Strip tags for meta properties

### DIFF
--- a/src/Data/Property.php
+++ b/src/Data/Property.php
@@ -7,6 +7,7 @@ namespace Hofff\Contao\SocialTags\Data;
 use Contao\StringUtil;
 
 use function sprintf;
+use function strip_tags;
 
 class Property
 {

--- a/src/Data/Property.php
+++ b/src/Data/Property.php
@@ -50,14 +50,14 @@ class Property
                 '<meta%s property="%s" content="%s">',
                 sprintf(' prefix="%s"', StringUtil::specialchars($this->getNamespaceDeclaration())),
                 StringUtil::specialchars($this->getPrefixedName()),
-                StringUtil::specialchars($this->content)
+                StringUtil::specialchars(strip_tags($this->content))
             );
         }
 
         return sprintf(
             '<meta property="%s" content="%s">',
             StringUtil::specialchars($this->getPrefixedName()),
-            StringUtil::specialchars($this->content)
+            StringUtil::specialchars(strip_tags($this->content))
         );
     }
 


### PR DESCRIPTION
In the extractor classes `replaceInsertTags` is used for all fields. However, if you use

```
DAS {{br}}MODEL {{br}}UND SEIN {{br}}TÜFTLER
```

in a news headline for example (in order to force breaks at specific points), the resulting `og:title` for example will be

```html
<meta prefix="og: http://ogp.me/ns#" property="og:title" content="DAS  &lt;br&gt;MODELL &lt;br&gt;UND SEIN  &lt;br&gt;TÜFTLER">
```

which will then look like this when sharing:

![image](https://user-images.githubusercontent.com/4970961/125468442-6e22cb2f-298e-4507-832b-c0d5382124b8.png)

To fix this any HTML tags should be stripped for these HTML attributes.
